### PR TITLE
Resetup frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ cd client
 bun dev
 ```
 
+Note: sometimes bun bugs out and localhost wont refresh on save. rerun bun dev if such is the case
+
 ### Development backend
 
 ```bash

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,29 +1,18 @@
-import { useState } from "preact/hooks";
+//import { useState } from "preact/hooks";
+import { Route, Router } from "preact-router";
 
-import styles from "./app.css";
+import Home from "./routes/home";
+import SomeOtherPage from "./routes/someOtherPage";
 
 export function App() {
-  const [count, setCount] = useState(0);
-
   return (
-    <>
-      <div>
-        <a href="https://bun.sh" target="_blank">
-          <img src="/favicon.ico" class="logo" alt="Bun logo" />
-        </a>
-      </div>
-      <h1 onClick={() => console.log("asdfas")}>Bun +asdfasdfasdfasfd </h1>
-      <div class={styles.card}>
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/app.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p class="read-the-docs">
-        Click on the Bun and Preact logos to learn more
-      </p>
-    </>
+    <div id="app">
+      <main>
+        <Router>
+          <Route path="/" component={Home} />
+          <Route path="/someOtherPage" component={SomeOtherPage} />
+        </Router>
+      </main>
+    </div>
   );
 }

--- a/client/src/routes/home/index.tsx
+++ b/client/src/routes/home/index.tsx
@@ -1,0 +1,12 @@
+import { Link } from "preact-router";
+
+const Home = () => {
+  return (
+    <>
+      <div>homepage</div>
+      <Link href="/someOtherPage">Me</Link>
+    </>
+  );
+};
+
+export default Home;

--- a/client/src/routes/someOtherPage/index.tsx
+++ b/client/src/routes/someOtherPage/index.tsx
@@ -1,0 +1,5 @@
+const SomeOtherPage = () => {
+  return <div>SomeOtherPage</div>;
+};
+
+export default SomeOtherPage;

--- a/client/src/sw.js
+++ b/client/src/sw.js
@@ -1,0 +1,4 @@
+import { getFiles, setupPrecaching, setupRouting } from "preact-cli/sw/";
+
+setupRouting();
+setupPrecaching(getFiles());


### PR DESCRIPTION
The previous frontend was using bun with nextjs and many things didn't work because of bugs caused by bun. The frontend is now rewritten to use bun with [preact](https://preactjs.com/) instead.